### PR TITLE
feat: update peer dependencies to allow NestJS v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "typescript": "3.7.5"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.3",
-    "@nestjs/core": "^9.0.3",
+    "@nestjs/common": "^9.0.3 || ^10.0.0",
+    "@nestjs/core": "^9.0.3 || ^10.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.6"
   },


### PR DESCRIPTION
Fix: https://github.com/node-casbin/nest-authz/issues/157