### PR TITLE
feat: allows user to access underlying casbin enforcer

### DIFF
--- a/src/services/authz-management.service.ts
+++ b/src/services/authz-management.service.ts
@@ -9,7 +9,7 @@ import * as casbin from 'casbin';
 export class AuthZManagementService {
   constructor(
     @Inject(AUTHZ_ENFORCER)
-    private readonly enforcer: casbin.Enforcer
+    public readonly enforcer: casbin.Enforcer
   ) {}
 
   /**

--- a/src/services/authz-rbac.service.ts
+++ b/src/services/authz-rbac.service.ts
@@ -11,7 +11,7 @@ import * as casbin from 'casbin';
 export class AuthZRBACService {
   constructor(
     @Inject(AUTHZ_ENFORCER)
-    private readonly enforcer: casbin.Enforcer
+    public readonly enforcer: casbin.Enforcer
   ) {}
 
   /**


### PR DESCRIPTION
allows user to access underlying casbin enforcer to make use of any api, such as enforce, making it more flexible

Make it possible for users to call `enforce()` in a service.