### PR TITLE
feat: Add ABAC support and make custom actions more flexible

### DIFF
--- a/src/authz.guard.ts
+++ b/src/authz.guard.ts
@@ -45,7 +45,7 @@ export class AuthZGuard implements CanActivate {
         user: AuthUser,
         permission: Permission
       ): Promise<boolean> => {
-        const { possession , resource, action } = permission;
+        const { possession, resource, action } = permission;
 
         if (!this.options.enablePossession) {
           return this.enforcer.enforce(user, resource, action);

--- a/src/authz.module.ts
+++ b/src/authz.module.ts
@@ -13,6 +13,10 @@ import { AuthZRBACService, AuthZManagementService } from './services';
 })
 export class AuthZModule {
   static register(options: AuthZModuleOptions): DynamicModule {
+    if (options.enablePossession === undefined) {
+      options.enablePossession = true;
+    }
+
     const moduleOptionsProvider = {
       provide: AUTHZ_MODULE_OPTIONS,
       useValue: options || {}

--- a/src/decorators/use-permissions.decorator.ts
+++ b/src/decorators/use-permissions.decorator.ts
@@ -1,4 +1,4 @@
-import { CustomDecorator, SetMetadata } from '@nestjs/common';
+import { SetMetadata } from '@nestjs/common';
 import { Permission } from '../interfaces/permission.interface';
 import { PERMISSIONS_METADATA } from '../authz.constants';
 import { ExecutionContext } from '@nestjs/common';

--- a/src/decorators/use-permissions.decorator.ts
+++ b/src/decorators/use-permissions.decorator.ts
@@ -1,7 +1,8 @@
-import { SetMetadata } from '@nestjs/common';
+import { CustomDecorator, SetMetadata } from '@nestjs/common';
 import { Permission } from '../interfaces/permission.interface';
 import { PERMISSIONS_METADATA } from '../authz.constants';
 import { ExecutionContext } from '@nestjs/common';
+import { AuthPossession } from '../types';
 
 const defaultIsOwn = (ctx: ExecutionContext): boolean => false;
 
@@ -9,8 +10,11 @@ const defaultIsOwn = (ctx: ExecutionContext): boolean => false;
  * You can define multiple permissions, but only
  * when all of them satisfied, could you access the route.
  */
-export const UsePermissions = (...permissions: Permission[]) => {
+export const UsePermissions = (...permissions: Permission[]): any => {
   const perms = permissions.map(item => {
+    if (!item.possession) {
+      item.possession = AuthPossession.ANY;
+    }
     if (!item.isOwn) {
       item.isOwn = defaultIsOwn;
     }

--- a/src/interfaces/authz-module-options.interface.ts
+++ b/src/interfaces/authz-module-options.interface.ts
@@ -5,11 +5,13 @@ import {
   ForwardReference,
   Type
 } from '@nestjs/common';
+import { AuthUser } from '../types';
 
 export interface AuthZModuleOptions<T = any> {
   model?: string;
   policy?: string | Promise<T>;
-  usernameFromContext: (context: ExecutionContext) => string;
+  enablePossession?: boolean;
+  userFromContext: (context: ExecutionContext) => AuthUser;
   enforcerProvider?: Provider<any>;
   /**
    * Optional list of imported modules that export the providers which are

--- a/src/interfaces/permission.interface.ts
+++ b/src/interfaces/permission.interface.ts
@@ -1,9 +1,9 @@
-import { AuthActionVerb, AuthPossession, CustomAuthActionVerb } from '../types';
+import { AuthActionVerb, AuthPossession, CustomAuthActionVerb, AuthResource } from '../types';
 import { ExecutionContext } from '@nestjs/common';
 
 export interface Permission {
-  resource: string;
+  resource: AuthResource;
   action: AuthActionVerb | CustomAuthActionVerb;
-  possession: AuthPossession;
+  possession?: AuthPossession;
   isOwn?: (ctx: ExecutionContext) => boolean;
 }

--- a/src/interfaces/permission.interface.ts
+++ b/src/interfaces/permission.interface.ts
@@ -1,4 +1,9 @@
-import { AuthActionVerb, AuthPossession, CustomAuthActionVerb, AuthResource } from '../types';
+import {
+  AuthActionVerb,
+  AuthPossession,
+  CustomAuthActionVerb,
+  AuthResource
+} from '../types';
 import { ExecutionContext } from '@nestjs/common';
 
 export interface Permission {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,10 @@ export enum AuthActionVerb {
 
 export type CustomAuthActionVerb = string;
 
+export type AuthResource = string | Record<string, any>;
+
+export type AuthUser = string | Record<string, any>;
+
 export enum AuthPossession {
   ANY = 'any',
   OWN = 'own',

--- a/test/use-permissions.decorator.spec.ts
+++ b/test/use-permissions.decorator.spec.ts
@@ -13,12 +13,17 @@ describe('@UsePermissions()', () => {
         resource: 'test',
         action: AuthActionVerb.READ,
         possession: AuthPossession.ANY
+      },
+      {
+        resource: {type: 'testType', id: 'testId'},
+        action: AuthActionVerb.CREATE,
+        possession: AuthPossession.OWN,
       }
     ];
     class TestController {
       @UsePermissions(...permissions)
-      getData() {
-        return null;
+      getData(): boolean {
+        return false;
       }
     }
     const res = Reflect.getMetadata(


### PR DESCRIPTION
Hello,

After filing the ticket #167, I decided to create a fork which adds the requested feature. ABAC models allow request parameters to be object or class instances instead of only strings, however, the current implementation of `nest-authz` requires strings. This means that ABAC models in Casbin are unusable. In this PR, I added support by doing the following:

- I defined user and resource types `AuthUser` and `AuthResource` as `string | Record<string, any>`.
- `usernameFromContext` has been changed to `userFromContext` which returns an `AuthUser`.

Additionally, in order to support more flexible naming of actions (especially in use cases without the concept of possession), I made possession optional:

- I added an option called `enablePosession` to the module options that defaults to `true` if not provided.
- I made `possession` optional in `@UsePermissions` and it defaults to `AuthPossession.ANY`
- If possession is enabled, actions are still formatted as `"{actionVerb}:{possession}"`. If possession is disabled, actions are formatted as `"{actionVerb}"`.

Let me know what you think and if there are any improvements to make.