### PR TITLE
feat: allow AuthZGuard children to access injected dependencies

### DIFF
--- a/src/authz.guard.ts
+++ b/src/authz.guard.ts
@@ -20,7 +20,6 @@ import { UnauthorizedException } from '@nestjs/common';
 import { AuthPossession, AuthResource, AuthUser, BatchApproval } from './types';
 import { AuthZModuleOptions } from './interfaces/authz-module-options.interface';
 
-
 @Injectable()
 export class AuthZGuard implements CanActivate {
   constructor(

--- a/src/authz.guard.ts
+++ b/src/authz.guard.ts
@@ -20,6 +20,7 @@ import { UnauthorizedException } from '@nestjs/common';
 import { AuthPossession, AuthResource, AuthUser, BatchApproval } from './types';
 import { AuthZModuleOptions } from './interfaces/authz-module-options.interface';
 
+
 @Injectable()
 export class AuthZGuard implements CanActivate {
   constructor(

--- a/src/authz.guard.ts
+++ b/src/authz.guard.ts
@@ -23,9 +23,9 @@ import { AuthZModuleOptions } from './interfaces/authz-module-options.interface'
 @Injectable()
 export class AuthZGuard implements CanActivate {
   constructor(
-    private readonly reflector: Reflector,
-    @Inject(AUTHZ_ENFORCER) private enforcer: casbin.Enforcer,
-    @Inject(AUTHZ_MODULE_OPTIONS) private options: AuthZModuleOptions
+    protected readonly reflector: Reflector,
+    @Inject(AUTHZ_ENFORCER) protected enforcer: casbin.Enforcer,
+    @Inject(AUTHZ_MODULE_OPTIONS) protected options: AuthZModuleOptions
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {


### PR DESCRIPTION
Children of AuthZGuard may now access the injected reflector, enforcer, and options. This allows projects that need custom enforcement calls (e.g., RBAC + domains) to make simple changes, such as overriding the enforce method, without needing to ignore TypeScript errors related to accessibility.