### PR TITLE
feat: loosen reflect-metadata peerDependency for Nest v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cz-conventional-changelog": "3.3.0",
     "jest": "24.9.0",
     "prettier": "1.19.1",
-    "reflect-metadata": "0.1.13",
+    "reflect-metadata": "^0.1.13 || ^0.2.0",
     "rimraf": "3.0.1",
     "rxjs": "^6.0.0",
     "standard-version": "8.0.2",
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@nestjs/common": "^9.0.3 || ^10.0.0",
     "@nestjs/core": "^9.0.3 || ^10.0.0",
-    "reflect-metadata": "^0.1.13",
+    "reflect-metadata": "^0.1.13 || ^0.2.0",
     "rxjs": "^7.5.6"
   },
   "repository": {


### PR DESCRIPTION
The following occurs when trying to install nest-authz in a Nest.js 10.0.0 project.

❯ npm i nest-authz
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: promandev@0.0.1
npm error Found: reflect-metadata@0.2.2
npm error node_modules/reflect-metadata
npm error   reflect-metadata@"^0.2.0" from the root project
npm error   peer reflect-metadata@"^0.1.12 || ^0.2.0" from @nestjs/common@10.4.17
npm error   node_modules/@nestjs/common
npm error     @nestjs/common@"^10.0.0" from the root project
npm error     peer @nestjs/common@"^9.0.3 || ^10.0.0" from nest-authz@2.15.0
npm error     node_modules/nest-authz
npm error       nest-authz@"*" from the root project
npm error     5 more (@nestjs/core, @nestjs/microservices, ...)
npm error   3 more (@nestjs/core, @nestjs/microservices, @nestjs/websockets)
npm error
npm error Could not resolve dependency:
npm error peer reflect-metadata@"^0.1.13" from nest-authz@2.15.0
npm error node_modules/nest-authz
npm error   nest-authz@"*" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
